### PR TITLE
WIP xk6 TimescaleDB output

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,7 +2,6 @@ package timescaledb
 
 import (
 	"fmt"
-	"os"
 	"strconv"
 	"time"
 )
@@ -11,23 +10,29 @@ type config struct {
 	// Connection URL in the form specified in the libpq docs,
 	// see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING):
 	// postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...]
-	URL              string        `json:"addr" envconfig:"K6_TIMESCALEDB_URL"`
-	PushInterval     time.Duration `json:"pushInterval,omitempty" envconfig:"K6_TIMESCALEDB_PUSH_INTERVAL"`
-	ConcurrentWrites int           `json:"concurrentWrites,omitempty" envconfig:"K6_TIMESCALEDB_CONCURRENT_WRITES"`
+	URL              string
+	PushInterval     time.Duration
+	ConcurrentWrites int
 }
 
-func getEnvConfig() (config, error) {
-	pushInterval, err := time.ParseDuration(os.Getenv("K6_TIMESCALEDB_PUSH_INTERVAL"))
+func getEnvConfig(env map[string]string) (config, error) {
+	url, ok := env["K6_TIMESCALEDB_URL"]
+	if !ok {
+		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL")
+	}
+
+	pushInterval, err := time.ParseDuration(env["K6_TIMESCALEDB_PUSH_INTERVAL"])
 	if err != nil {
 		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_PUSH_INTERVAL: %w", err)
 	}
-	concurrentWrites, err := strconv.Atoi(os.Getenv("K6_TIMESCALEDB_CONCURRENT_WRITES"))
+
+	concurrentWrites, err := strconv.Atoi(env["K6_TIMESCALEDB_CONCURRENT_WRITES"])
 	if err != nil {
 		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_CONCURRENT_WRITES: %w", err)
 	}
 
 	return config{
-		URL:              os.Getenv("K6_TIMESCALEDB_URL"),
+		URL:              url,
 		PushInterval:     pushInterval,
 		ConcurrentWrites: concurrentWrites,
 	}, nil

--- a/config.go
+++ b/config.go
@@ -1,39 +1,62 @@
 package timescaledb
 
 import (
+	"encoding/json"
 	"fmt"
-	"strconv"
 	"time"
+
+	"go.k6.io/k6/lib/types"
+
+	"gopkg.in/guregu/null.v3"
 )
 
 type config struct {
 	// Connection URL in the form specified in the libpq docs,
 	// see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING):
 	// postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...]
-	URL              string
-	PushInterval     time.Duration
-	ConcurrentWrites int
+	URL          null.String
+	PushInterval types.NullDuration
 }
 
-func getEnvConfig(env map[string]string) (config, error) {
-	url, ok := env["K6_TIMESCALEDB_URL"]
-	if !ok {
-		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL")
+func newConfig() config {
+	return config{
+		URL:          null.NewString("postgresql://localhost/myk6timescaleDB", false),
+		PushInterval: types.NewNullDuration(time.Second, false),
 	}
+}
+
+func (c *config) apply(cfg config) {
+	if cfg.URL.Valid {
+		c.URL = cfg.URL
+	}
+	if cfg.PushInterval.Valid {
+		c.PushInterval = cfg.PushInterval
+	}
+}
+
+func getConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, url string) (config, error) {
+	result := newConfig()
+
+	if jsonRawConf != nil {
+		var jsonConf config
+		err := json.Unmarshal(jsonRawConf, &jsonConf)
+		if err != nil {
+			return result, err
+		}
+		result.apply(jsonConf)
+	}
+
+	pgUrl, ok := env["K6_TIMESCALEDB_URL"]
+	if !ok {
+		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL: %q", pgUrl)
+	}
+	result.apply(config{URL: null.StringFrom(pgUrl)})
 
 	pushInterval, err := time.ParseDuration(env["K6_TIMESCALEDB_PUSH_INTERVAL"])
 	if err != nil {
 		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_PUSH_INTERVAL: %w", err)
 	}
+	result.apply(config{PushInterval: types.NewNullDuration(pushInterval, true)})
 
-	concurrentWrites, err := strconv.Atoi(env["K6_TIMESCALEDB_CONCURRENT_WRITES"])
-	if err != nil {
-		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_CONCURRENT_WRITES: %w", err)
-	}
-
-	return config{
-		URL:              url,
-		PushInterval:     pushInterval,
-		ConcurrentWrites: concurrentWrites,
-	}, nil
+	return result, nil
 }

--- a/config.go
+++ b/config.go
@@ -25,13 +25,14 @@ func newConfig() config {
 	}
 }
 
-func (c *config) apply(cfg config) {
+func (c config) apply(cfg config) config {
 	if cfg.URL.Valid {
 		c.URL = cfg.URL
 	}
 	if cfg.PushInterval.Valid {
 		c.PushInterval = cfg.PushInterval
 	}
+	return c
 }
 
 func getConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, url string) (config, error) {
@@ -43,20 +44,20 @@ func getConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, u
 		if err != nil {
 			return result, err
 		}
-		result.apply(jsonConf)
+		result = result.apply(jsonConf)
 	}
 
 	pgUrl, ok := env["K6_TIMESCALEDB_URL"]
 	if !ok {
 		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL: %q", pgUrl)
 	}
-	result.apply(config{URL: null.StringFrom(pgUrl)})
+	result = result.apply(config{URL: null.StringFrom(pgUrl)})
 
 	pushInterval, err := time.ParseDuration(env["K6_TIMESCALEDB_PUSH_INTERVAL"])
 	if err != nil {
 		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_PUSH_INTERVAL: %w", err)
 	}
-	result.apply(config{PushInterval: types.NewNullDuration(pushInterval, true)})
+	result = result.apply(config{PushInterval: types.NewNullDuration(pushInterval, true)})
 
 	return result, nil
 }

--- a/config.go
+++ b/config.go
@@ -3,6 +3,8 @@ package timescaledb
 import (
 	"encoding/json"
 	"fmt"
+	"net/url"
+	"strings"
 	"time"
 
 	"go.k6.io/k6/lib/types"
@@ -14,50 +16,107 @@ type config struct {
 	// Connection URL in the form specified in the libpq docs,
 	// see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING):
 	// postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...]
-	URL          null.String
-	PushInterval types.NullDuration
+	PgUrl        null.String        `json:"pg_url"`
+	PushInterval types.NullDuration `json:"push_interval"`
+	dbName       null.String
+	addr         null.String
 }
 
 func newConfig() config {
 	return config{
-		URL:          null.NewString("postgresql://localhost/myk6timescaleDB", false),
+		PgUrl:        null.NewString("postgresql://localhost/myk6timescaleDB", false),
 		PushInterval: types.NewNullDuration(time.Second, false),
+		dbName:       null.NewString("myk6timescaleDB", false),
+		addr:         null.NewString("postgresql://localhost", false),
 	}
 }
 
-func (c config) apply(cfg config) config {
-	if cfg.URL.Valid {
-		c.URL = cfg.URL
+func (c config) apply(modifiedConf config) config {
+	if modifiedConf.PgUrl.Valid {
+		c.PgUrl = modifiedConf.PgUrl
 	}
-	if cfg.PushInterval.Valid {
-		c.PushInterval = cfg.PushInterval
+	if modifiedConf.PushInterval.Valid {
+		c.PushInterval = modifiedConf.PushInterval
+	}
+	if modifiedConf.dbName.Valid {
+		c.dbName = modifiedConf.dbName
+	}
+	if modifiedConf.addr.Valid {
+		c.addr = modifiedConf.addr
 	}
 	return c
 }
 
-func getConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, url string) (config, error) {
-	result := newConfig()
+func getConsolidatedConfig(jsonRawConf json.RawMessage, env map[string]string, confArg string) (config, error) {
+	consolidatedConf := newConfig()
 
 	if jsonRawConf != nil {
-		var jsonConf config
-		err := json.Unmarshal(jsonRawConf, &jsonConf)
-		if err != nil {
-			return result, err
+		var rawJsonConf config
+		if err := json.Unmarshal(jsonRawConf, &rawJsonConf); err != nil {
+			return config{}, fmt.Errorf("problem unmarshalling json: %w", err)
 		}
-		result = result.apply(jsonConf)
+		consolidatedConf = consolidatedConf.apply(rawJsonConf)
+
+		jsonUrlConf, err := parseUrl(consolidatedConf.PgUrl.String)
+		if err != nil {
+			return config{}, fmt.Errorf("problem parsing url provided in json %q: %w",
+				consolidatedConf.PgUrl.String, err)
+		}
+		consolidatedConf = consolidatedConf.apply(jsonUrlConf)
 	}
 
-	pgUrl, ok := env["K6_TIMESCALEDB_URL"]
-	if !ok {
-		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL: %q", pgUrl)
+	envPgUrl, ok := env["K6_TIMESCALEDB_URL"]
+	if ok {
+		envUrlConf, err := parseUrl(envPgUrl)
+		if err != nil {
+			return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_URL %q: %w", envPgUrl, err)
+		}
+		consolidatedConf = consolidatedConf.apply(envUrlConf)
 	}
-	result = result.apply(config{URL: null.StringFrom(pgUrl)})
 
-	pushInterval, err := time.ParseDuration(env["K6_TIMESCALEDB_PUSH_INTERVAL"])
+	envPushInterval, ok := env["K6_TIMESCALEDB_PUSH_INTERVAL"]
+	if ok {
+		pushInterval, err := time.ParseDuration(envPushInterval)
+		if err != nil {
+			return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_PUSH_INTERVAL: %w", err)
+		}
+		consolidatedConf = consolidatedConf.apply(config{PushInterval: types.NewNullDuration(pushInterval, true)})
+	}
+
+	if confArg != "" {
+		parsedConfArg, err := parseUrl(confArg)
+		if err != nil {
+			return config{}, fmt.Errorf("invalid config argument %q: %w", confArg, err)
+		}
+		consolidatedConf = consolidatedConf.apply(parsedConfArg)
+	}
+
+	return consolidatedConf, nil
+}
+
+func parseUrl(text string) (config, error) {
+	u, err := url.Parse(text)
 	if err != nil {
-		return config{}, fmt.Errorf("invalid K6_TIMESCALEDB_PUSH_INTERVAL: %w", err)
+		return config{}, err
 	}
-	result = result.apply(config{PushInterval: types.NewNullDuration(pushInterval, true)})
+	var parsedConf config
+	parsedConf.PgUrl = null.StringFrom(u.Scheme + "://" + u.User.String() + "@" + u.Host + u.Path)
 
-	return result, nil
+	if u.Host != "" {
+		parsedConf.addr = null.StringFrom(u.Scheme + "://" + u.Host)
+	}
+	if dbName := strings.TrimPrefix(u.Path, "/"); dbName != "" {
+		parsedConf.dbName = null.StringFrom(dbName)
+	}
+	for k, vs := range u.Query() {
+		switch k {
+		case "push_interval":
+			if err := parsedConf.PushInterval.UnmarshalText([]byte(vs[0])); err != nil {
+				return config{}, err
+			}
+		default:
+			return config{}, fmt.Errorf("unknown query parameter: %s", k)
+		}
+	}
+	return parsedConf, err
 }

--- a/config.go
+++ b/config.go
@@ -1,0 +1,18 @@
+package timescaledb
+
+import (
+	"go.k6.io/k6/lib/types"
+	"gopkg.in/guregu/null.v3"
+)
+
+type config struct {
+	// Connection URL in the form specified in the libpq docs,
+	// see https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING):
+	// postgresql://[user[:password]@][netloc][:port][,...][/dbname][?param1=value1&...]
+	URL              null.String        `json:"addr" envconfig:"K6_TIMESCALEDB_URL"`
+	PushInterval     types.NullDuration `json:"pushInterval,omitempty" envconfig:"K6_TIMESCALEDB_PUSH_INTERVAL"`
+	ConcurrentWrites null.Int           `json:"concurrentWrites,omitempty" envconfig:"K6_TIMESCALEDB_CONCURRENT_WRITES"`
+
+	addr null.String
+	db   null.String
+}

--- a/config_test.go
+++ b/config_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_getConsolidatedConfig_succeeds(t *testing.T) {
+func Test_getConsolidatedConfig_Succeeds(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(
 		[]byte(`{"pg_url":"postgres://user:password@localhost:5433/mydbname","push_interval":"2s"}`),
 		map[string]string{
@@ -27,7 +27,7 @@ func Test_getConsolidatedConfig_succeeds(t *testing.T) {
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_from_json_and_populates_config_fields_from_json_url(t *testing.T) {
+func Test_getConsolidatedConfig_FromJsonAndPopulatesConfigFieldsFromJsonUrl(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(
 		[]byte(`{"pg_url":"postgres://user:password@localhost:5433/mydbname","push_interval":"2s"}`),
 		nil,
@@ -41,7 +41,7 @@ func Test_getConsolidatedConfig_from_json_and_populates_config_fields_from_json_
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_from_env_variables(t *testing.T) {
+func Test_getConsolidatedConfig_FromEnvVariables(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(
 		nil,
 		map[string]string{
@@ -59,7 +59,7 @@ func Test_getConsolidatedConfig_from_env_variables(t *testing.T) {
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_env_variable_takes_precedence_without_config_arg(t *testing.T) {
+func Test_getConsolidatedConfig_EnvVariableTakesPrecedenceWithoutConfigArg(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(
 		[]byte(`{"pg_url":"postgres://user:password@localhost:1111/jsonDBName","push_interval":"5s","db_name":"jsonDBName"}`),
 		map[string]string{
@@ -77,7 +77,7 @@ func Test_getConsolidatedConfig_env_variable_takes_precedence_without_config_arg
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_config_argument_takes_precedence(t *testing.T) {
+func Test_getConsolidatedConfig_ConfigArgumentTakesPrecedence(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(
 		[]byte(`{"pg_url":"postgres://jsonUser:jsonPassword@localhost:1111/jsonDBName","push_interval":"5s","db_name":"jsonDBName"}`),
 		map[string]string{
@@ -95,7 +95,7 @@ func Test_getConsolidatedConfig_config_argument_takes_precedence(t *testing.T) {
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_returns_default_values(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsDefaultValues(t *testing.T) {
 	actualConfig, err := getConsolidatedConfig(nil, nil, "")
 
 	assert.NoError(t, err)
@@ -107,37 +107,37 @@ func Test_getConsolidatedConfig_returns_default_values(t *testing.T) {
 	}, actualConfig)
 }
 
-func Test_getConsolidatedConfig_returns_error_for_invalid_json(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsErrorForInvalidJson(t *testing.T) {
 	_, err := getConsolidatedConfig([]byte(`invalid`), nil, "")
 	assert.Error(t, err)
 }
 
-func Test_getConsolidatedConfig_returns_error_for_invalid_json_url(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsErrorForInvalidJsonUrl(t *testing.T) {
 	_, err := getConsolidatedConfig([]byte(`{"pg_url":"http://foo.com/?foo\nbar"}`), nil, "")
 	assert.Error(t, err)
 }
 
-func Test_getConsolidatedConfig_returns_error_for_invalid_env_url(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsErrorForInvalidEnvUrl(t *testing.T) {
 	_, err := getConsolidatedConfig(nil, map[string]string{
 		"K6_TIMESCALEDB_URL": "http://foo.com/?foo\nbar",
 	}, "")
 	assert.Error(t, err)
 }
 
-func Test_getConsolidatedConfig_returns_error_for_invalid_env_push_interval(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsErrorForInvalidEnvPushInterval(t *testing.T) {
 	_, err := getConsolidatedConfig(nil, map[string]string{
 		"K6_TIMESCALEDB_PUSH_INTERVAL": "invalid",
 	}, "")
 	assert.Error(t, err)
 }
 
-func Test_getConsolidatedConfig_returns_error_for_invalid_config_argument_url(t *testing.T) {
+func Test_getConsolidatedConfig_ReturnsErrorForInvalidConfigArgumentUrl(t *testing.T) {
 	_, err := getConsolidatedConfig(nil, nil, "http://foo.com/?foo\nbar")
 
 	assert.Error(t, err)
 }
 
-func Test_parselUrl_succeeds(t *testing.T) {
+func Test_parselUrl_Succeeds(t *testing.T) {
 	actualConfig, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=2s")
 
 	assert.NoError(t, err)
@@ -149,19 +149,19 @@ func Test_parselUrl_succeeds(t *testing.T) {
 	}, actualConfig)
 }
 
-func Test_parselUrl_returns_error_for_unknown_query(t *testing.T) {
+func Test_parselUrl_ReturnsErrorForUnknownQuery(t *testing.T) {
 	_, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=2s&unknown=value")
 
 	assert.Error(t, err)
 }
 
-func Test_parselUrl_returns_error_for_invalid_push_interval(t *testing.T) {
+func Test_parselUrl_ReturnsErrorForInvalidPushInterval(t *testing.T) {
 	_, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=invalid")
 
 	assert.Error(t, err)
 }
 
-func Test_parselUrl_returns_error_for_invalid_input(t *testing.T) {
+func Test_parselUrl_ReturnsErrorForInvalidInput(t *testing.T) {
 	_, err := parseUrl("http://foo.com/?foo\nbar")
 
 	assert.Error(t, err)

--- a/config_test.go
+++ b/config_test.go
@@ -1,0 +1,168 @@
+package timescaledb
+
+import (
+	"testing"
+	"time"
+
+	"go.k6.io/k6/lib/types"
+	"gopkg.in/guregu/null.v3"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_getConsolidatedConfig_succeeds(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(
+		[]byte(`{"pg_url":"postgres://user:password@localhost:5433/mydbname","push_interval":"2s"}`),
+		map[string]string{
+			"K6_TIMESCALEDB_URL":           "postgres://user:password@localhost:5433/mydbname",
+			"K6_TIMESCALEDB_PUSH_INTERVAL": "2s",
+		},
+		"postgres://user:password@localhost:5433/mydbname?push_interval=2s")
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://user:password@localhost:5433/mydbname"),
+		PushInterval: types.NullDurationFrom(2 * time.Second),
+		addr:         null.StringFrom("postgres://localhost:5433"),
+		dbName:       null.StringFrom("mydbname"),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_from_json_and_populates_config_fields_from_json_url(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(
+		[]byte(`{"pg_url":"postgres://user:password@localhost:5433/mydbname","push_interval":"2s"}`),
+		nil,
+		"")
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://user:password@localhost:5433/mydbname"),
+		PushInterval: types.NullDurationFrom(2 * time.Second),
+		addr:         null.StringFrom("postgres://localhost:5433"),
+		dbName:       null.StringFrom("mydbname"),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_from_env_variables(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(
+		nil,
+		map[string]string{
+			"K6_TIMESCALEDB_URL":           "postgres://user:password@localhost:5433/mydbname",
+			"K6_TIMESCALEDB_PUSH_INTERVAL": "2s",
+		},
+		"")
+
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://user:password@localhost:5433/mydbname"),
+		PushInterval: types.NullDurationFrom(2 * time.Second),
+		addr:         null.StringFrom("postgres://localhost:5433"),
+		dbName:       null.StringFrom("mydbname"),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_env_variable_takes_precedence_without_config_arg(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(
+		[]byte(`{"pg_url":"postgres://user:password@localhost:1111/jsonDBName","push_interval":"5s","db_name":"jsonDBName"}`),
+		map[string]string{
+			"K6_TIMESCALEDB_URL":           "postgres://user:password@localhost:5433/mydbname",
+			"K6_TIMESCALEDB_PUSH_INTERVAL": "2s",
+		},
+		"")
+
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://user:password@localhost:5433/mydbname"),
+		PushInterval: types.NullDurationFrom(2 * time.Second),
+		addr:         null.StringFrom("postgres://localhost:5433"),
+		dbName:       null.StringFrom("mydbname"),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_config_argument_takes_precedence(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(
+		[]byte(`{"pg_url":"postgres://jsonUser:jsonPassword@localhost:1111/jsonDBName","push_interval":"5s","db_name":"jsonDBName"}`),
+		map[string]string{
+			"K6_TIMESCALEDB_URL":           "postgres://user:password@localhost:5433/mydbname",
+			"K6_TIMESCALEDB_PUSH_INTERVAL": "2s",
+		},
+		"postgres://confUser:confPassword@localhost:2222/confDBName?push_interval=8s")
+
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://confUser:confPassword@localhost:2222/confDBName"),
+		PushInterval: types.NullDurationFrom(time.Duration(8000000000)),
+		addr:         null.StringFrom("postgres://localhost:2222"),
+		dbName:       null.StringFrom("confDBName"),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_returns_default_values(t *testing.T) {
+	actualConfig, err := getConsolidatedConfig(nil, nil, "")
+
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.NewString("postgresql://localhost/myk6timescaleDB", false),
+		PushInterval: types.NewNullDuration(time.Duration(1000000000), false),
+		addr:         null.NewString("postgresql://localhost", false),
+		dbName:       null.NewString("myk6timescaleDB", false),
+	}, actualConfig)
+}
+
+func Test_getConsolidatedConfig_returns_error_for_invalid_json(t *testing.T) {
+	_, err := getConsolidatedConfig([]byte(`invalid`), nil, "")
+	assert.Error(t, err)
+}
+
+func Test_getConsolidatedConfig_returns_error_for_invalid_json_url(t *testing.T) {
+	_, err := getConsolidatedConfig([]byte(`{"pg_url":"http://foo.com/?foo\nbar"}`), nil, "")
+	assert.Error(t, err)
+}
+
+func Test_getConsolidatedConfig_returns_error_for_invalid_env_url(t *testing.T) {
+	_, err := getConsolidatedConfig(nil, map[string]string{
+		"K6_TIMESCALEDB_URL": "http://foo.com/?foo\nbar",
+	}, "")
+	assert.Error(t, err)
+}
+
+func Test_getConsolidatedConfig_returns_error_for_invalid_env_push_interval(t *testing.T) {
+	_, err := getConsolidatedConfig(nil, map[string]string{
+		"K6_TIMESCALEDB_PUSH_INTERVAL": "invalid",
+	}, "")
+	assert.Error(t, err)
+}
+
+func Test_getConsolidatedConfig_returns_error_for_invalid_config_argument_url(t *testing.T) {
+	_, err := getConsolidatedConfig(nil, nil, "http://foo.com/?foo\nbar")
+
+	assert.Error(t, err)
+}
+
+func Test_parselUrl_succeeds(t *testing.T) {
+	actualConfig, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=2s")
+
+	assert.NoError(t, err)
+	assert.Equal(t, config{
+		PgUrl:        null.StringFrom("postgres://user:password@localhost:5433/mydbname"),
+		PushInterval: types.NullDurationFrom(2 * time.Second),
+		addr:         null.StringFrom("postgres://localhost:5433"),
+		dbName:       null.StringFrom("mydbname"),
+	}, actualConfig)
+}
+
+func Test_parselUrl_returns_error_for_unknown_query(t *testing.T) {
+	_, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=2s&unknown=value")
+
+	assert.Error(t, err)
+}
+
+func Test_parselUrl_returns_error_for_invalid_push_interval(t *testing.T) {
+	_, err := parseUrl("postgres://user:password@localhost:5433/mydbname?push_interval=invalid")
+
+	assert.Error(t, err)
+}
+
+func Test_parselUrl_returns_error_for_invalid_input(t *testing.T) {
+	_, err := parseUrl("http://foo.com/?foo\nbar")
+
+	assert.Error(t, err)
+}

--- a/go.mod
+++ b/go.mod
@@ -6,9 +6,6 @@ require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
-	github.com/stretchr/testify v1.7.0
 	go.k6.io/k6 v0.33.0
-	gopkg.in/guregu/null.v3 v3.5.0
+	gopkg.in/guregu/null.v3 v3.5.0 // indirect
 )
-
-replace go.k6.io/k6 => /Users/shirley/go/src/github.com/grafana/k6

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,7 @@ module github.com/shirleyleu/xk6-output-timescaledb
 go 1.16
 
 require (
-	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
-	github.com/jackc/pgx v3.6.2+incompatible
+	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.33.0

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,8 @@
+module github.com/shirleyleu/xk6-output-timescaledb
+
+go 1.16
+
+require (
+	go.k6.io/k6 v0.33.0
+	gopkg.in/guregu/null.v3 v3.5.0
+)

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	go.k6.io/k6 v0.33.1-0.20210805085120-a733b306b344
+	go.k6.io/k6 master
 )

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,12 @@ module github.com/shirleyleu/xk6-output-timescaledb
 go 1.16
 
 require (
+	github.com/cockroachdb/apd v1.1.0 // indirect
+	github.com/gofrs/uuid v4.0.0+incompatible // indirect
+	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
+	github.com/jackc/pgx v3.6.2+incompatible
+	github.com/lib/pq v1.10.2 // indirect
+	github.com/shopspring/decimal v1.2.0 // indirect
 	go.k6.io/k6 v0.33.0
 	gopkg.in/guregu/null.v3 v3.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,7 @@ go 1.16
 require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	go.k6.io/k6 master
+	github.com/sirupsen/logrus v1.8.1
+	go.k6.io/k6 v0.33.1-0.20210805085120-a733b306b344
+	gopkg.in/guregu/null.v3 v3.3.0
 )

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,9 @@ require (
 	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/lib/pq v1.10.2 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.33.0
 	gopkg.in/guregu/null.v3 v3.5.0
 )
+
+replace go.k6.io/k6 => /Users/shirley/go/src/github.com/grafana/k6

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,5 @@ go 1.16
 require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.33.0
-	gopkg.in/guregu/null.v3 v3.5.0 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	go.k6.io/k6 v0.33.0
 	gopkg.in/guregu/null.v3 v3.5.0
 )

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/shirleyleu/xk6-output-timescaledb
 go 1.16
 
 require (
-	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.33.1-0.20210805085120-a733b306b344

--- a/go.mod
+++ b/go.mod
@@ -5,5 +5,5 @@ go 1.16
 require (
 	github.com/jackc/pgtype v1.8.1
 	github.com/jackc/pgx/v4 v4.13.0
-	go.k6.io/k6 v0.33.0
+	go.k6.io/k6 v0.33.1-0.20210805085120-a733b306b344
 )

--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,9 @@ module github.com/shirleyleu/xk6-output-timescaledb
 go 1.16
 
 require (
-	github.com/cockroachdb/apd v1.1.0 // indirect
-	github.com/gofrs/uuid v4.0.0+incompatible // indirect
 	github.com/jackc/fake v0.0.0-20150926172116-812a484cc733 // indirect
 	github.com/jackc/pgx v3.6.2+incompatible
-	github.com/lib/pq v1.10.2 // indirect
-	github.com/shopspring/decimal v1.2.0 // indirect
+	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.33.0
 	gopkg.in/guregu/null.v3 v3.5.0

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.16
 require (
 	github.com/jackc/pgx/v4 v4.13.0
 	github.com/sirupsen/logrus v1.8.1
+	github.com/stretchr/testify v1.7.0
 	go.k6.io/k6 v0.33.1-0.20210805085120-a733b306b344
 	gopkg.in/guregu/null.v3 v3.3.0
 )

--- a/output.go
+++ b/output.go
@@ -1,7 +1,11 @@
 package timescaledb
 
 import (
+	"context"
+	"time"
+
 	"github.com/jackc/pgx"
+	"github.com/jackc/pgx/pgtype"
 	"github.com/sirupsen/logrus"
 
 	"go.k6.io/k6/output"
@@ -14,9 +18,13 @@ func init() {
 	})
 }
 
+var _ output.Output = &Output{}
+
 type Output struct {
-	Pool   *pgx.ConnPool
-	Config config
+	output.SampleBuffer
+	periodicFlusher *output.PeriodicFlusher
+	Pool            *pgx.ConnPool
+	Config          config
 
 	thresholds map[string][]*dbThreshold
 
@@ -77,10 +85,60 @@ func (o *Output) Start() error {
 		}
 	}
 
+	pf, err := output.NewPeriodicFlusher(time.Duration(o.Config.PushInterval.Duration), o.commit)
+	if err != nil {
+		return err
+	}
+
+	o.logger.Debug("TimescaleDB: Running!")
+	o.periodicFlusher = pf
+
 	o.Pool.Release(conn)
 	return nil
 }
 
-func (o *Output) AddMetricSamples(samples []stats.SampleContainer) {}
+func (o *Output) commit() {
+	sampleContainers := o.GetBufferedSamples()
+	for _, sc := range sampleContainers {
+		samples := sc.GetSamples()
+		logrus.Debug("TimescaleDB: Committing...")
+		o.logger.WithField("samples", len(samples)).Debug("TimescaleDB: Writing...")
 
-func (o *Output) Stop() error { return nil }
+		start := time.Now()
+		batch := o.Pool.BeginBatch()
+		for _, s := range samples {
+			tags := s.Tags.CloneTags()
+			batch.Queue("INSERT INTO samples (ts, metric, value, tags) VALUES ($1, $2, $3, $4)",
+				[]interface{}{s.Time, s.Metric.Name, s.Value, tags},
+				[]pgtype.OID{pgtype.TimestamptzOID, pgtype.VarcharOID, pgtype.Float4OID, pgtype.JSONBOID},
+				nil)
+		}
+
+		for _, t := range o.thresholds {
+			for _, threshold := range t {
+				batch.Queue("UPDATE thresholds SET last_failed = $1 WHERE id = $2",
+					[]interface{}{threshold.threshold.LastFailed, threshold.id},
+					[]pgtype.OID{pgtype.BoolOID, pgtype.Int4OID},
+					nil)
+			}
+		}
+
+		if err := batch.Send(context.Background(), nil); err != nil {
+			o.logger.WithError(err).Error("TimescaleDB: Couldn't send batch of inserts")
+		}
+		if err := batch.Close(); err != nil {
+			o.logger.WithError(err).Error("TimescaleDB: Couldn't close batch and release connection")
+		}
+
+		t := time.Since(start)
+		o.logger.WithField("t", t).Debug("TimescaleDB: Batch written!")
+	}
+}
+
+func (o *Output) Stop() error {
+	o.logger.Debug("Stopping...")
+	defer o.logger.Debug("Stopped!")
+	o.periodicFlusher.Stop()
+	o.Pool.Close()
+	return nil
+}

--- a/output.go
+++ b/output.go
@@ -1,0 +1,17 @@
+package timescaledb
+
+import "github.com/grafana/k6/stats"
+
+type Output struct{}
+
+func (o *Output) Description() string{
+	return ""
+}
+
+func (o *Output) Start() error{
+	return nil
+}
+
+func (o *Output) AddMetricSamples(samples []stats.SampleContainer) {}
+
+func (o *Output) Stop() error {return nil}

--- a/output.go
+++ b/output.go
@@ -173,6 +173,12 @@ func (o *Output) flushMetrics() {
 	defer conn.Release()
 
 	br := conn.SendBatch(context.Background(), &batch)
+	defer func() {
+		if err := br.Close(); err != nil {
+			o.logger.WithError(err).Warn("flushMetrics: Couldn't close batch results")
+		}
+	}()
+
 	for i := 0; i < batch.Len(); i++ {
 		ct, err := br.Exec()
 		if err != nil {

--- a/output.go
+++ b/output.go
@@ -121,7 +121,6 @@ func (o *Output) Start() error {
 				threshold.threshold.LastFailed).Scan(&threshold.id)
 			if err != nil {
 				o.logger.WithError(err).Debug("TimescaleDB: Failed to insert threshold")
-				panic(err)
 			}
 		}
 	}
@@ -171,7 +170,6 @@ func (o *Output) commit() {
 		br := conn.SendBatch(context.Background(), batch)
 		if _, err := br.Exec(); err != nil {
 			o.logger.WithError(err).Error("TimescaleDB: Couldn't write samples and update thresholds")
-			panic(err)
 		}
 
 		conn.Release()

--- a/output.go
+++ b/output.go
@@ -3,7 +3,6 @@ package timescaledb
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/jackc/pgtype"
@@ -35,24 +34,18 @@ func newOutput(params output.Params) (output.Output, error) {
 		return nil, fmt.Errorf("TimescaleDB: Unable to create connection pool: %w", err)
 	}
 
-	thresholds := make(map[string][]*dbThreshold)
-	for name, t := range params.ScriptOptions.Thresholds {
-		for _, threshold := range t.Thresholds {
-			thresholds[name] = append(thresholds[name], &dbThreshold{id: -1, threshold: threshold})
-		}
-	}
-
-	return &Output{
-		Pool:       pool,
-		Config:     config,
-		thresholds: thresholds,
+	o := Output{
+		Pool:   pool,
+		Config: config,
 		logger: params.Logger.WithFields(logrus.Fields{
 			"output": "TimescaleDB",
 		}),
-	}, nil
+	}
+
+	return &o, nil
 }
 
-var _ output.Output = &Output{}
+var _ interface{ output.WithThresholds } = &Output{}
 
 type Output struct {
 	output.SampleBuffer
@@ -67,6 +60,21 @@ type Output struct {
 
 func (o *Output) Description() string {
 	return "TimescaleDB"
+}
+
+// SetThresholds receives the thresholds before the output is Start()-ed.
+func (o *Output) SetThresholds(thresholds map[string]stats.Thresholds) {
+	ths := make(map[string][]*dbThreshold)
+	for metric, fullTh := range thresholds {
+		for _, t := range fullTh.Thresholds {
+			ths[metric] = append(ths[metric], &dbThreshold{
+				id:        -1,
+				threshold: t,
+			})
+		}
+	}
+
+	o.thresholds = ths
 }
 
 type dbThreshold struct {
@@ -84,7 +92,6 @@ const expectedDatabaseSchema = `CREATE TABLE IF NOT EXISTS samples (
 		id serial,
 		ts timestamptz NOT NULL DEFAULT current_timestamp,
 		metric varchar(128) NOT NULL,
-		tags jsonb,
 		threshold varchar(128) NOT NULL,
 		abort_on_fail boolean DEFAULT FALSE,
 		delay_abort_eval varchar(128),
@@ -110,13 +117,14 @@ func (o *Output) Start() error {
 		o.logger.WithError(err).Debug("TimescaleDB: Couldn't create database schema; most likely harmless")
 	}
 
-	for name, t := range o.thresholds {
-		for _, threshold := range t {
-			metric, _, tags := parseThresholdName(name)
-			err = conn.QueryRow(context.Background(),
-				"INSERT INTO thresholds (metric, tags, threshold, abort_on_fail, delay_abort_eval, last_failed) VALUES ($1, $2, $3, $4, $5, $6) RETURNING id",
-				metric, tags, threshold.threshold.Source, threshold.threshold.AbortOnFail, threshold.threshold.AbortGracePeriod.String(),
-				threshold.threshold.LastFailed).Scan(&threshold.id)
+	for metric, thresholds := range o.thresholds {
+		for _, t := range thresholds {
+			err = conn.QueryRow(context.Background(), `
+				INSERT INTO thresholds (metric, threshold, abort_on_fail, delay_abort_eval, last_failed)
+				VALUES ($1, $2, $3, $4, $5)
+				RETURNING id`,
+				metric, t.threshold.Source, t.threshold.AbortOnFail, t.threshold.AbortGracePeriod.String(), t.threshold.LastFailed).
+				Scan(&t.id)
 			if err != nil {
 				o.logger.WithError(err).Debug("TimescaleDB: Failed to insert threshold")
 			}
@@ -174,36 +182,11 @@ func (o *Output) commit() {
 		o.logger.WithField("t", t).Debug("TimescaleDB: Batch written!")
 	}
 }
+
 func (o *Output) Stop() error {
 	o.logger.Debug("Stopping...")
 	defer o.logger.Debug("Stopped!")
 	o.periodicFlusher.Stop()
 	o.Pool.Close()
 	return nil
-}
-
-func parseThresholdName(name string) (string, string, map[string]string) {
-	parts := strings.SplitN(strings.TrimSuffix(name, "}"), "{", 2)
-	if len(parts) == 1 {
-		return parts[0], "", make(map[string]string, 0)
-	}
-
-	kvs := strings.Split(parts[1], ",")
-	tags := make(map[string]string, len(kvs))
-	for _, kv := range kvs {
-		if kv == "" {
-			continue
-		}
-		parts := strings.SplitN(kv, ":", 2)
-
-		key := strings.TrimSpace(strings.Trim(parts[0], `"'`))
-		if len(parts) != 2 {
-			tags[key] = ""
-			continue
-		}
-
-		value := strings.TrimSpace(strings.Trim(parts[1], `"'`))
-		tags[key] = value
-	}
-	return parts[0], parts[1], tags
 }

--- a/output.go
+++ b/output.go
@@ -31,7 +31,7 @@ type Output struct {
 }
 
 func (o *Output) Description() string {
-	return "TimescaleDB"
+	return fmt.Sprintf("TimescaleDB (%s)", o.Config.addr.String)
 }
 
 func newOutput(params output.Params) (output.Output, error) {
@@ -40,7 +40,7 @@ func newOutput(params output.Params) (output.Output, error) {
 		return nil, fmt.Errorf("problem parsing config: %w", err)
 	}
 
-	pconf, err := pgxpool.ParseConfig(config.URL.String)
+	pconf, err := pgxpool.ParseConfig(config.PgUrl.String)
 	if err != nil {
 		return nil, fmt.Errorf("TimescaleDB: Unable to parse config: %w", err)
 	}
@@ -107,7 +107,7 @@ func (o *Output) Start() error {
 	}
 	defer conn.Release()
 
-	_, err = conn.Exec(context.Background(), "CREATE DATABASE myk6timescaleDB")
+	_, err = conn.Exec(context.Background(), "CREATE DATABASE "+o.Config.dbName.String)
 	if err != nil {
 		o.logger.WithError(err).Debug("Start: Couldn't create database; most likely harmless")
 	}

--- a/output.go
+++ b/output.go
@@ -1,6 +1,9 @@
 package timescaledb
 
 import (
+	"github.com/jackc/pgx"
+	"github.com/sirupsen/logrus"
+
 	"go.k6.io/k6/output"
 	"go.k6.io/k6/stats"
 )
@@ -12,12 +15,43 @@ func init() {
 }
 
 type Output struct {
+	Pool   *pgx.ConnPool
 	Config config
+
+	thresholds map[string][]*dbThreshold
+
+	logger logrus.FieldLogger
 }
 
 func (o *Output) Description() string {
 	return "Output to TimescaleDB"
 }
+
+type dbThreshold struct {
+	id        int
+	threshold *stats.Threshold
+}
+
+// TimescaleDB database schema expected by this collector
+const databaseSchema = `CREATE TABLE IF NOT EXISTS samples (
+		ts timestamptz NOT NULL DEFAULT current_timestamp,
+		metric varchar(128) NOT NULL,
+		tags jsonb,
+		value real
+	);
+	CREATE TABLE IF NOT EXISTS thresholds (
+		id serial,
+		ts timestamptz NOT NULL DEFAULT current_timestamp,
+		metric varchar(128) NOT NULL,
+		tags jsonb,
+		threshold varchar(128) NOT NULL,
+		abort_on_fail boolean DEFAULT FALSE,
+		delay_abort_eval varchar(128),
+		last_failed boolean DEFAULT FALSE
+	);
+	SELECT create_hypertable('samples', 'ts');
+	CREATE INDEX IF NOT EXISTS idx_samples_ts ON samples (ts DESC);
+	CREATE INDEX IF NOT EXISTS idx_thresholds_ts ON thresholds (ts DESC);`
 
 func (o *Output) Start() error {
 	return nil

--- a/output.go
+++ b/output.go
@@ -1,17 +1,28 @@
 package timescaledb
 
-import "github.com/grafana/k6/stats"
+import (
+	"go.k6.io/k6/output"
+	"go.k6.io/k6/stats"
+)
 
-type Output struct{}
-
-func (o *Output) Description() string{
-	return ""
+func init() {
+	output.RegisterExtension("timescaledb", func(params output.Params) (output.Output, error) {
+		return &Output{}, nil
+	})
 }
 
-func (o *Output) Start() error{
+type Output struct {
+	Config config
+}
+
+func (o *Output) Description() string {
+	return "Output to TimescaleDB"
+}
+
+func (o *Output) Start() error {
 	return nil
 }
 
 func (o *Output) AddMetricSamples(samples []stats.SampleContainer) {}
 
-func (o *Output) Stop() error {return nil}
+func (o *Output) Stop() error { return nil }

--- a/output.go
+++ b/output.go
@@ -20,9 +20,9 @@ func init() {
 }
 
 func newOutput(params output.Params) (output.Output, error) {
-	config, err := getEnvConfig()
+	config, err := getEnvConfig(params.Environment)
 	if err != nil {
-		return nil, fmt.Errorf("problem parsing environmental variables: %w", err)
+		return nil, fmt.Errorf("problem parsing config: %w", err)
 	}
 
 	if config.ConcurrentWrites <= 0 {


### PR DESCRIPTION
A PR in order to get any early feedback on the code itself as I do not know if I used some parts correctly like `output.SampleBuffer` and the periodic flushing.
Work was based on https://github.com/grafana/k6/pull/1233 and the influxdb output implementation.

Locally, the build seems to be working (config from env variables only at the moment).
I'm able to see the samples table populated in my local timescale db, but I have not yet checked thresholds, push interval, concurrent writes...

To do:
- [ ] Add docker-compose
- [ ] Add README
- [ ] Add configurable log level