### PR TITLE
Add dashboard listing tests with a nice url

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,7 @@ services:
       - ./grafana-datasource.yaml:/etc/grafana/provisioning/datasources/datasource.yaml
       - ./samples/dashboards.yaml:/etc/grafana/provisioning/dashboards/dashboards.yaml
       - ./samples/grafana_dashboard_timescaledb.json:/var/lib/grafana/dashboards/grafana_dashboard_timescaledb.json
+      - ./samples/dashboard-tests.json:/var/lib/grafana/dashboards/dashboard-tests.json
 
   k6:
     build: .

--- a/samples/dashboard-tests.json
+++ b/samples/dashboard-tests.json
@@ -1,0 +1,113 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "columns": [],
+      "datasource": "mytimescaledb",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 19,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "options": {},
+      "pageSize": null,
+      "showHeader": true,
+      "sort": {
+        "col": 0,
+        "desc": true
+      },
+      "styles": [
+        {
+          "alias": "Time",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "Time",
+          "type": "date"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "link": true,
+          "linkUrl": "${__cell:raw}",
+          "pattern": "url",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "format": "table",
+          "group": [],
+          "metricColumn": "none",
+          "rawQuery": true,
+          "rawSql": "SELECT distinct tags->>'testid' as test_id, min(ts) as start, max(ts) as end,\n    ('/d/a21-pyAWz/test-result?orgId=1&from='\n    || extract(epoch from date_trunc('second', min(ts)))*1000\n    || '&to=' || extract(epoch from date_trunc('second', max(ts)))*1000) as url\nFROM samples\nGROUP BY 1\nORDER BY 3 DESC, 2 DESC",
+          "refId": "A",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "column"
+              }
+            ]
+          ],
+          "timeColumn": "time",
+          "where": [
+            {
+              "name": "$__timeFilter",
+              "params": [],
+              "type": "macro"
+            }
+          ]
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Test runs",
+      "transform": "table",
+      "type": "table"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 20,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Test Runs List",
+  "uid": "UoYDJHJZk",
+  "version": 4
+}


### PR DESCRIPTION
This was somehow missed by me in the original porting of the dashboards
from https://github.com/grafana/open-source-load-testing-stack